### PR TITLE
Change the ProblemList Sort Way

### DIFF
--- a/hoj-springboot/DataBackup/src/main/java/top/hcode/hoj/mapper/xml/GroupProblemMapper.xml
+++ b/hoj-springboot/DataBackup/src/main/java/top/hcode/hoj/mapper/xml/GroupProblemMapper.xml
@@ -26,7 +26,7 @@
         ) as total
         FROM problem p
         WHERE p.auth = 1 AND p.gid = #{gid}
-        ORDER BY LENGTH(p.problem_id) ASC, p.problem_id ASC
+        ORDER BY REGEXP_SUBSTR(p.problem_id, '[A-Z]+[a-z]+') asc, CONVERT(REGEXP_SUBSTR(p.problem_id, '[0-9]+'),SIGNED) asc, p.problem_id asc
     </select>
 
     <select id="getProblemTag" resultType="top.hcode.hoj.pojo.entity.problem.Tag">

--- a/hoj-springboot/DataBackup/src/main/java/top/hcode/hoj/mapper/xml/ProblemMapper.xml
+++ b/hoj-springboot/DataBackup/src/main/java/top/hcode/hoj/mapper/xml/ProblemMapper.xml
@@ -51,7 +51,7 @@
                 and p.is_remote=false
             </if>
         </where>
-        order by length(p.problem_id) asc,p.problem_id asc
+        ORDER BY REGEXP_SUBSTR(p.problem_id, '[A-Z]+[a-z]+') asc, CONVERT(REGEXP_SUBSTR(p.problem_id, '[0-9]+'),SIGNED) asc, p.problem_id asc
     </select>
 
     <!-- 子查询 :为了防止分页总数据数出错-->


### PR DESCRIPTION
Due to formatting issues with the problem_id in CF and some question banks, it is not possible to simply sort them directly through length and character sorting.
Just like the id 1832C,1832D1,1832D2,1832E, if sort them directly through length and character, the results are 1832C,1832E,1832D1,1832D2, this is wrong