### PR TITLE
build: 使用contentHash生成js；修复本地运行热更新慢

### DIFF
--- a/hoj-vue/vue.config.js
+++ b/hoj-vue/vue.config.js
@@ -88,11 +88,16 @@ module.exports={
     config.plugin('webpack-bundle-analyzer') // 查看打包文件体积大小
       .use(require('webpack-bundle-analyzer').BundleAnalyzerPlugin)
     // ============注入cdn end============
+    if(isProduction) {
+      config.output.filename('assets/js/app.[contentHash].js')
+    } else {
+      config.output.filename('assets/js/app.js')
+    }
   },
   configureWebpack: (config) => {
     // 用cdn方式引入，则构建时要忽略相关资源
     const plugins = [];
-    if (isProduction || devNeedCdn){
+    if (isProduction){
       config.externals = cdn.externals
       config.mode = 'production';
       config["performance"] = {//打包文件大小配置
@@ -125,6 +130,8 @@ module.exports={
             minRatio: 0.8 // 压缩比
         })
       )
+    } else {
+      config.externals = cdn.externals
     }
   }
 


### PR DESCRIPTION
1. 打包输出的app.js根据文件内容生成文件名
2. 本地运行时不压缩代码，不需要使用uglifyjs-webpack-plugin，compression-webpack-plugin，加快热更新速度