### PR TITLE
Fix directory name in README for consistency with actual repo name

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -55,7 +55,7 @@ sudo apt-get update && sudo apt-get install -y vim curl git
 
 sudo apt-get update
 
-git clone https://github.com/HimitZH/HOJ-Deploy.git && cd hoj-deploy && cd standAlone
+git clone https://github.com/HimitZH/HOJ-Deploy.git && cd  HOJ-Deploy && cd standAlone
 
 # Change some configuration such as password.
 vim .env


### PR DESCRIPTION
This PR corrects the directory name used in the installation steps in README. The previous command `cd hoj-deploy` did not match the actual cloned folder name `HOJ-Deploy`, which could lead to confusion or errors during setup. This update improves clarity and ensures smoother onboarding for new users.